### PR TITLE
Updated google sign-in method for new GoogleSignIn 7.0

### DIFF
--- a/OTFMagicBox/Onboarding/OnboardingOptionsViewController.swift
+++ b/OTFMagicBox/Onboarding/OnboardingOptionsViewController.swift
@@ -279,14 +279,15 @@ public class OnboardingOptionsViewController: ORKQuestionStepViewController, ASA
         }
         
         let signInConfig = GIDConfiguration(clientID: clientID)
-        GIDSignIn.sharedInstance.signIn(with: signInConfig, presenting: self) { [unowned self] user, error in
-            if let error = error {
+        GIDSignIn.sharedInstance.configuration = signInConfig
+        GIDSignIn.sharedInstance.signIn(withPresenting: self) { [unowned self] signInResult, error in
+            if let error {
                 showError(error)
                 return
             }
             
-            // If sign in succeeded, display the app's main content View.
-            guard let user = user, let idToken = user.authentication.idToken else {
+            guard let signInResult,
+                  let idToken = signInResult.user.idToken?.tokenString else {
                 showError(ForgeError.empty)
                 return
             }

--- a/OTFMagicBox/Onboarding/OnboardingOptionsViewController.swift
+++ b/OTFMagicBox/Onboarding/OnboardingOptionsViewController.swift
@@ -286,6 +286,7 @@ public class OnboardingOptionsViewController: ORKQuestionStepViewController, ASA
                 return
             }
             
+            // If sign in succeeded, display the app's main content View.
             guard let signInResult,
                   let idToken = signInResult.user.idToken?.tokenString else {
                 showError(ForgeError.empty)

--- a/OTFMagicBox/Onboarding/OnboardingOptionsViewController.swift
+++ b/OTFMagicBox/Onboarding/OnboardingOptionsViewController.swift
@@ -279,16 +279,14 @@ public class OnboardingOptionsViewController: ORKQuestionStepViewController, ASA
         }
         
         let signInConfig = GIDConfiguration(clientID: clientID)
-        GIDSignIn.sharedInstance.configuration = signInConfig
-        GIDSignIn.sharedInstance.signIn(withPresenting: self) { [unowned self] signInResult, error in
+        GIDSignIn.sharedInstance.signIn(with: signInConfig, presenting: self) { [unowned self] user, error in
             if let error {
                 showError(error)
                 return
             }
             
             // If sign in succeeded, display the app's main content View.
-            guard let signInResult,
-                  let idToken = signInResult.user.idToken?.tokenString else {
+            guard let user = user, let idToken = user.authentication.idToken else {
                 showError(ForgeError.empty)
                 return
             }

--- a/Podfile
+++ b/Podfile
@@ -8,6 +8,6 @@ target 'OTFMagicBox' do
   source 'https://github.com/TheraForge/OTFCocoapodSpecs'
 
   pod 'OTFToolBox/CareHealth', '1.0.2-beta'
-  pod 'GoogleSignIn'
+  pod 'GoogleSignIn', '6.2.2'
 
 end


### PR DESCRIPTION
I tried running this SDK on my machine and, upon installing the third-party dependencies with `pod install`, some errors showed up on the Google Sign-In method on the Onboarding part. Currently, the Podfile is not specifying an version of the `GoogleSignIn` library, so it attempted to install the latest version available.

[Upon reviewing the changelog for the latest version (7.0) of the GoogleSignIn library](https://github.com/google/GoogleSignIn-iOS/releases/tag/7.0.0), I discovered that the sign-in configuration setup has been moved from the signIn method to a new property of GIDSignIn, and that the method signature has been updated.

This pull request implements the required changes to enable the use of the new properties and methods introduced in version 7.0 of the `GoogleSignIn` library in Magic Box, while preserving all existing rules and functionality.

