### PR TITLE
Updated README Documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,8 @@ For more details on the features of the SDK and on the TheraForge Cloud setup pr
 * [Features](#magicbox-features)
 * [Installation](#magicbox-installation)
 * [Usage](#app-usage)
-* [Registration on Apple Developer Portal](##registration-on-apple-developer-portal)
-* [Xcode Setup](##xcode-setup)
+* [Registration on Apple Developer Portal](#registration-on-apple-developer-portal)
+* [Xcode Setup](#xcode-setup)
 * [CI/CD Setup](#cicd-setup)
 * [License](#license)
 

--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ The MagicBox app installation process requires the installation of the ToolBox S
 
 ## Prerequisites <a name="Prerequisites"></a>
 
-- macOS Cataline 10.15.4 (Intel) or macOS 11 Big Sur (Apple Silicon)
+- macOS Catalina 10.15.4 (Intel) or macOS 11 Big Sur (Apple Silicon)
 - Xcode 13.0 or later
 - CocoaPods
 - iOS 14.0 or later

--- a/README.md
+++ b/README.md
@@ -360,46 +360,105 @@ Example: change $(PRODUCT_NAME) to “My Digital App”.
 
 You can change the tint color, the label colors, font type and size to customize the look of your application:
 
-[Color Codes in designConfig Section](/OTFMagicBox/AppSysParameters.yml#L83-L177)
+```yml
+designConfig:
+    # Offset value.
+    - name: "offset"
+      textValue: "20"
+      
+    # Color codes
+    
+    # Please choose the colors according to Human Interface Guidelines from Apple.
+    # Refer here https://developer.apple.com/design/human-interface-guidelines/ios/visual-design/color
+    
+    - name: "tintColor"
+      textValue: "Blue"
+    - name: "label"
+      textValue: "Teal"
+    - name: "secondaryLabel"
+      textValue: "Brown"
+    # ...
+    
+    # Fonts
+    - name: "largeTitleFontSize"
+      textValue: "20"
+    - name: "titleFontName"
+      textValue: "Gotham-Book"
+    - name: "titleFontSize"
+      textValue: "17"
+    # ...    
+```
 
 ## Set up the TheraForge Cloud API Key
 
 Update the API key field to access the TheraForge Secure Cloud service for synchronization and communication with the web dashboards:
 
-```yaml
+```yml
 # AppSysParameters.yml
 DataModel:
    # ...
    apiKey: "<set_your_api_key_here>"
 ```
 
-[API Key Configuration Section](/OTFMagicBox/AppSysParameters.yml#L194-L195)
-
 ## Customize Onboarding
 
-To customize the onboarding process, go to the onboarding section in the `AppSysParameters.yml` file and add as many onboarding pages as you need. You can add the image types of your choice such as Emoji, SF Symbols and assets. In the description you can write the text explaining each particular onboarding page:
+To customize the onboarding process, go to the onboarding section in the `ModuleAppSysParameter.yml` file and add as many onboarding pages as you need. You can add the image types of your choice such as Emoji, SF Symbols and assets. In the description you can write the text explaining each particular onboarding page:
 
-[Onbarding Configuration Section](/OTFMagicBox/AppSysParameters.yml#L220-L228)
+```yml
+# ModuleAppSysParameter.yml
+
+onboarding:
+ - image: "Splash Image"
+   icon: "stethoscope"
+   title: "Welcome to MagicBox"
+   color: "Black"
+   description: "Your health care app"
+ 
+ - image: "Splash Image"
+   icon: "speedometer"
+   title: "This is another custom onboarding step"
+   color: "Black"
+   description: "MagicBox allows you to customize the onboarding experience with custom steps"
+```
 
 ## Customize Consent
 
-To customize the Consent process of your application go to the Consent section in the `AppSysParameters.yml` file and add/modify the required sections. Follow the instructions given in the yaml file to add the correct type of consent sections:
+To customize the Consent process of your application go to the Consent section in the `ModuleAppSysParameter.yml` file and add/modify the required sections. Follow the instructions given in the yaml file to add the correct type of consent sections:
 
-[Consent Configuration Section](/OTFMagicBox/AppSysParameters.yml#L230-L286)
+```yml
+# ModuleAppSysParameter.yml
+ 
+## Custom Consent Section, if you want to display this in your application then assign true value otherwise false for the "show" key.
+- show: "true"
+  summary: "This is custom section."
+  content: "Describe here what the user is consenting to in this step of the onboarding"
+```
 
 ## Customize Registration and Login
 
-Go to the Registration section in the `AppSysParameters.yml` file and change the settings for *Date Of Birth* and *Gender* to `true` if you want to display those fields in your Registration form, otherwise set them to `false`:
+Go to the Registration section in the `ModuleAppSysParameter.yml` file and change the settings for *Date Of Birth* and *Gender* to `true` if you want to display those fields in your Registration form, otherwise set them to `false`:
 
-[Registration Configuration Section](/OTFMagicBox/AppSysParameters.yml#L288-L293)
+```yml
+# ModuleAppSysParameter.yml
+
+registration:
+  showDateOfBirth: "true"
+  showGender: "true"
+```
 
 ## Configure Regular Login/Social Login
 
-Go to the Login section in the `AppSysParameters.yml` file and customize the title and the description.
+Go to the Login section in the `ModuleAppSysParameter.yml` file and customize the title and the description.
 
 If you want to use the *Sign up With Apple* feature, then change the corresponding setting to `true`:
 
-[Login Configuration Section](/OTFMagicBox/AppSysParameters.yml#L295-L306)
+```yml
+# ModuleAppSysParameter.yml
+
+showAppleSignin:  "true"
+showGoogleSignin: "false"
+googleClientID: "add_your_client_id_here"
+```
 
 ## Configure the Passcode
 
@@ -417,8 +476,6 @@ Go to the Passcode section in the `ModuleAppSysParameter.yml` file and change th
    passcodeType: "4"
 ```
 
-[Passcode Configuration Section](/OTFMagicBox/AppSysParameters.yml#L308-L316)
-
 
 ## Enable CareKit
 
@@ -429,8 +486,6 @@ If your application requires support for tasks (for example, for a care plan) an
 
 useCareKit: "true"
 ```
-
-[Carekit Configuration Section](/OTFMagicBox/AppSysParameters.yml#L327-L330)
 
 
 # Registration on Apple Developer Portal

--- a/README.md
+++ b/README.md
@@ -19,16 +19,16 @@ For more details on the features of the SDK and on the TheraForge Cloud setup pr
 
 # Table of Contents
 
-* [Overview](#Overview)
-* [Features](#Features)
-* [Installation](#Installation)
-* [Usage](#Usage)
-* [Registration on Apple Developer Portal](#Registration)
-* [Xcode Setup](#XcodeSetup)
-* [CI/CD Setup](#CICDSetup)
-* [License](#License)
+* [Overview](#overview)
+* [Features](#magicbox-features)
+* [Installation](#magicbox-installation)
+* [Usage](#app-usage)
+* [Registration on Apple Developer Portal](##registration-on-apple-developer-portal)
+* [Xcode Setup](##xcode-setup)
+* [CI/CD Setup](#cicd-setup)
+* [License](#license)
 
-# Overview <a name="Overview"></a>
+# Overview
 
 MagicBox app’s source code represents an example of how to use the frameworks in the TheraForge SDK. It will constantly evolve to incorporate and showcase new features of the SDK.
 
@@ -46,7 +46,7 @@ These are its primary characteristics:
 * CI/CD support via GitHub Actions.
 
 
-# MagicBox Features <a name="Features"></a>
+# MagicBox Features
 
 MagicBox includes the following customizable features:
 
@@ -144,7 +144,7 @@ Outcome is automatically synchronized securely across the cloud to all devices:
 
 <p align="center"><img src="Docs/35-Outcome-Synced.png" width=100% height=100%></p>
 
-# MagicBox Installation <a name="Installation"></a>
+# MagicBox Installation
 
 The MagicBox app installation process requires the installation of the ToolBox SDK and so it is similar to the process described in the [OTFToolBox](../../../OTFToolBox) Readme file.
 
@@ -325,7 +325,7 @@ For general troubleshooting tips to solve potential unexpected errors or crashes
 
 **[Xcode Quick Fix](https://developerinsider.co/clean-xcode-cache-quick-fix/)**
 
-# App Usage <a name="Usage"></a>
+# App Usage
 
 After following the above installation steps, go to the `AppSysParameters.yml` file in the root folder of your project.
 This yaml file contains the list of customizable parameters of your health application.
@@ -425,22 +425,22 @@ useCareKit: "true"
 [Carekit Configuration Section](/OTFMagicBox/AppSysParameters.yml#L327-L330)
 
 
-# Registration on Apple Developer Portal <a name="Registration"></a>
+# Registration on Apple Developer Portal
 
 If you need to run an application on a physical device (like your personal iPhone) and/or if you need to use TestFlight, then you need to register on the Apple Developer Portal.
 
 Register your project in your Apple developer account by following [these steps](APP-REGISTRATION.md).
 
-# Xcode Setup <a name="XcodeSetup"></a>
+# Xcode Setup
 
 Set up the Xcode application with your Apple developer account information as [described here](XCODE-SETUP.md).
 
-# CI/CD Setup <a name="CICDSetup"></a>
+# CI/CD Setup
 
 Configure your project using a CI and CD pipeline via GitHub Actions as [described here](/.github/CICD.md).
 
 
-# License <a name="License"></a>
+# License
 
 This project is made available under the terms of a modified BSD license. See the [LICENSE](LICENSE.md) file.
 

--- a/README.md
+++ b/README.md
@@ -19,16 +19,16 @@ For more details on the features of the SDK and on the TheraForge Cloud setup pr
 
 # Table of Contents
 
-* [Overview](#overview)
-* [Features](#magicbox-features)
-* [Installation](#magicbox-installation)
-* [Usage](#app-usage)
-* [Registration on Apple Developer Portal](#registration-on-apple-developer-portal)
-* [Xcode Setup](#xcode-setup)
-* [CI/CD Setup](#ci-cd-setup)
-* [License](#license)
+* [Overview](#Overview)
+* [Features](#Features)
+* [Installation](#Installation)
+* [Usage](#Usage)
+* [Registration on Apple Developer Portal](#Registration)
+* [Xcode Setup](#XcodeSetup)
+* [CI/CD Setup](#CICDSetup)
+* [License](#License)
 
-# Overview
+# Overview <a name="Overview"></a>
 
 MagicBox app’s source code represents an example of how to use the frameworks in the TheraForge SDK. It will constantly evolve to incorporate and showcase new features of the SDK.
 
@@ -46,7 +46,7 @@ These are its primary characteristics:
 * CI/CD support via GitHub Actions.
 
 
-# MagicBox Features
+# MagicBox Features <a name="Features"></a>
 
 MagicBox includes the following customizable features:
 
@@ -144,14 +144,14 @@ Outcome is automatically synchronized securely across the cloud to all devices:
 
 <p align="center"><img src="Docs/35-Outcome-Synced.png" width=100% height=100%></p>
 
-# MagicBox Installation
+# MagicBox Installation <a name="Installation"></a>
 
 The MagicBox app installation process requires the installation of the ToolBox SDK and so it is similar to the process described in the [OTFToolBox](../../../OTFToolBox) Readme file.
 
-* [Prerequisites](#prerequisites)
-* [App Setup](#app-setup)
+* [Prerequisites](#Prerequisites)
+* [App Setup](#App-Setup)
 
-## Prerequisites
+## Prerequisites <a name="Prerequisites"></a>
 
 An Intel-based Mac running [macOS Catalina 10.15.4 or later](https://developer.apple.com/documentation/xcode-release-notes/xcode-12-release-notes) or a Mac with Apple's M1 Silicon running [macOS 11 Big Sur](https://developer.apple.com/documentation/xcode-release-notes/xcode-12_2-release-notes). macOS 12 Monterey and Xcode 13 are supported.
 
@@ -211,7 +211,7 @@ Refer to our [Cocoapods Installation](Docs/Cocoapods.md) page for prerequisites,
 
 After successful installation of `git-lfs` and Cocoapods, you can install the MagicBox app.
 
-## App Setup
+## App Setup <a name="App-Setup"></a>
 
 ### 1. Create the Developer Directory and a Project Subdirectory 
 
@@ -325,7 +325,7 @@ For general troubleshooting tips to solve potential unexpected errors or crashes
 
 **[Xcode Quick Fix](https://developerinsider.co/clean-xcode-cache-quick-fix/)**
 
-# App Usage
+# App Usage <a name="Usage"></a>
 
 After following the above installation steps, go to the `AppSysParameters.yml` file in the root folder of your project.
 This yaml file contains the list of customizable parameters of your health application.
@@ -358,6 +358,13 @@ You can change the tint color, the label colors, font type and size to customize
 
 Update the API key field to access the TheraForge Secure Cloud service for synchronization and communication with the web dashboards:
 
+```yaml
+# AppSysParameters.yml
+DataModel:
+   # ...
+   apiKey: "<set_your_api_key_here>"
+```
+
 [API Key Configuration Section](/OTFMagicBox/AppSysParameters.yml#L194-L195)
 
 ## Customize Onboarding
@@ -388,7 +395,19 @@ If you want to use the *Sign up With Apple* feature, then change the correspondi
 
 ## Configure the Passcode
 
-Go to the Passcode section in the `AppSysParameters.yml` file and change the settings of passcode text and passcode type to 4 or 6 digits:
+Go to the Passcode section in the `ModuleAppSysParameter.yml` file and change the settings of passcode text and passcode type to either 4 or 6 digits:
+
+```yaml
+# ModuleAppSysParameter.yml
+
+ passcode:
+   enable: "false"
+   passcodeOnReturnText: "Welcome back!"
+   passcodeText: "Now you will create a passcode to identify yourself to the app and protect access to information you have entered."
+  
+   # Property passcodeType value can be either "4" or "6" only, which describes the number of digits for the passcode.
+   passcodeType: "4"
+```
 
 [Passcode Configuration Section](/OTFMagicBox/AppSysParameters.yml#L308-L316)
 
@@ -397,25 +416,31 @@ Go to the Passcode section in the `AppSysParameters.yml` file and change the set
 
 If your application requires support for tasks (for example, for a care plan) and contacts, then enable the `useCareKit` key, which allows you to display the contacts and list the tasks of the patients:
 
+```yml
+# AppSysParameters.yml
+
+useCareKit: "true"
+```
+
 [Carekit Configuration Section](/OTFMagicBox/AppSysParameters.yml#L327-L330)
 
 
-# Registration on Apple Developer Portal
+# Registration on Apple Developer Portal <a name="Registration"></a>
 
 If you need to run an application on a physical device (like your personal iPhone) and/or if you need to use TestFlight, then you need to register on the Apple Developer Portal.
 
 Register your project in your Apple developer account by following [these steps](APP-REGISTRATION.md).
 
-# Xcode Setup
+# Xcode Setup <a name="XcodeSetup"></a>
 
 Set up the Xcode application with your Apple developer account information as [described here](XCODE-SETUP.md).
 
-# CI CD Setup
+# CI/CD Setup <a name="CICDSetup"></a>
 
 Configure your project using a CI and CD pipeline via GitHub Actions as [described here](/.github/CICD.md).
 
 
-# License
+# License <a name="License"></a>
 
 This project is made available under the terms of a modified BSD license. See the [LICENSE](LICENSE.md) file.
 

--- a/README.md
+++ b/README.md
@@ -161,7 +161,9 @@ The MagicBox app installation process requires the installation of the ToolBox S
 
 ## Prerequisites <a name="Prerequisites"></a>
 
-An Intel-based Mac running [macOS Catalina 10.15.4 or later](https://developer.apple.com/documentation/xcode-release-notes/xcode-12-release-notes) or a Mac with Apple's M1 Silicon running [macOS 11 Big Sur](https://developer.apple.com/documentation/xcode-release-notes/xcode-12_2-release-notes). macOS 12 Monterey and Xcode 13 are supported.
+- macOS Cataline 10.15.4 (Intel) or macOS 11 Big Sur (Apple Silicon)
+- Xcode 13.0 or later
+- iOS 14.0 or later
 
 ### 1. Installation Prerequisites
 
@@ -171,7 +173,7 @@ In order to develop iOS apps, make sure to download Xcode, Apple's Integrated De
 
 If you haven't done it yet, follow this [Xcode article](https://medium.nextlevelswift.com/install-and-configure-xcode-7ed0c5592219) to install and configure it.
 
-(Note that in case of Xcode 13.2 Apple recommends to download it directly from the Apple Developer web site https://developer.apple.com/download/all/?q=Xcode. Some developers consider this installation method *preferable for all versions of Xcode*, that is, it’s considered a best practice. However, in this case you also need to install the *Command Line Tools for Xcode*, which are a separate download.)
+(Note that in case of Xcode 13.2 Apple recommends to [download it directly from the Apple Developer web site](https://developer.apple.com/download/all/?q=Xcode). Some developers consider this installation method *preferable for all versions of Xcode*, that is, it’s considered a best practice. However, in this case you also need to install the *Command Line Tools for Xcode*, which are a separate download.)
 
 <p align="center"><img src="Docs/27-cocoapods.png" width=50% height=50%></p>
 

--- a/README.md
+++ b/README.md
@@ -7,8 +7,6 @@ This sample application leverages TheraForge frameworks such as [OTFTemplateBox]
 For more details on the features of the SDK and on the TheraForge Cloud setup process (e.g., to obtain an API key), refer to the [OTFToolBox](../../../OTFToolBox) Readme file.
 
 ## Change Log
-* Release 1.0.0-beta: First beta release of the template app
-* Release 1.0.1-beta: Removed warnings, improved profile section, added UI samples and made various other improvements
 * Release 1.0.2-beta:
   * Made the application more configurable by adding color, font, font weight, background color in the yaml file.
   * Added app localization capabilities in the yaml file.
@@ -16,6 +14,16 @@ For more details on the features of the SDK and on the TheraForge Cloud setup pr
   * Added support for user account deletion to make the app more GDPR compliant.
   * Added CI/CD workflow to automate testing and deployment in TestFlight using GitHub Actions. Updated documentation with the required configuration steps.
   * Various fixes and improvements.
+<details>
+  <summary>Release 1.0.1-beta</summary>
+  Removed warnings, improved profile section, added UI samples and made various other improvements
+  
+</details>
+
+<details>
+  <summary>Release 1.0.0-beta</summary>
+  First beta release of the template app
+</details>
 
 # Table of Contents
 

--- a/README.md
+++ b/README.md
@@ -163,6 +163,7 @@ The MagicBox app installation process requires the installation of the ToolBox S
 
 - macOS Cataline 10.15.4 (Intel) or macOS 11 Big Sur (Apple Silicon)
 - Xcode 13.0 or later
+- CocoaPods
 - iOS 14.0 or later
 
 ### 1. Installation Prerequisites
@@ -262,17 +263,25 @@ Next, copy the URL of MagicBox's repository in GitHub to clone it. Remember to s
 
 This is the URL that you should get from GitHub:
 
-`https://github.com/TheraForge/OTFMagicBox.git`
+```
+https://github.com/TheraForge/OTFMagicBox.git
+```
 
 ### 3. Clone MagicBox's Repository to Install the App
 
 Then go back to the Terminal app in the `Developer` directory and enter `git clone` followed by the repository URL you just copied in the previous step:
 
+```
+git clone https://github.com/TheraForge/OTFMagicBox.git
+```
+
 <img src="Docs/17-GitClone.png">
 
 Then change the directory to the newly-created OTFMagicBox subdirectory:
 
-`cd OTFMagicBox`
+```
+cd OTFMagicBox
+```
 
 ### 4. List the Cloned Files
 


### PR DESCRIPTION
This pull request aims to fix some issues with our current README documentation and to include some improvements, making our documentation more accessible and easier to read

## Fixes

- Fixed the heading links for our Table of Contents

## Improvements

### Reordered Changelog

I've reordered the release versions under our changelog section from newest to oldest, so our users can quickly check what's new on our latest version without having to scroll past older releases. I've also created changed the older releases into collapsable sections, in order to keep them accessible, but without getting on the way of the rest of the document

### System Prerequisite List

I've converted the first prerequisite paragraph into a list, so it's presents the same information on a more glanceable manner. I've also added our current iOS target version and the CocoaPods dependency to this list, so users can get a heads-up of the iOS version they'll target on their product and the external dependency manager that we currently support

### Commands Into Code Blocks

I've moved and added some Terminal commands we instruct the user to use inside code blocks in our documentation, making them copiable with just a click and with a overall better presentation

### Code Blocks for Customization Settings

Currently, the customization section includes links for each setting which would take the user to the exact lines in the source file where the user would have to tweak. However, I noticed two issues with this approach:

- Most of these links were pointing to the wrong files or lines of code. By attempting to link the user to specific parts of our source code, we'd have to remember to always validate and update these links as our project evolves
- These links would not open on a new tab, which could make it difficult to keep the context of which part the user was reading in the documentation when navigating back

With these issues in mind, I've decided it'd be more appropriate to instead include code examples in code blocks in place of those links. With this approach, we can preview in the same page how our customization settings would look in code without the downside of this preview breaking if we change the source file

--- 

If you have any feedback for these suggestions or any other ideas, we can discuss them on the comments below.
You can preview how this document looks on [my fork of the MagicBox repository](https://github.com/tfmart/OTFMagicBox/tree/readme-update)