### PR TITLE
Fixes problem where Watch app was not displaying the current date scheduled events

### DIFF
--- a/OTFMagicBoxWatch/Views/CareKitListView.swift
+++ b/OTFMagicBoxWatch/Views/CareKitListView.swift
@@ -41,9 +41,16 @@ import WatchConnectivity
 
 struct CareKitListView: View {
     let carekitstore = OTFCareKitStoreManager.shared
+    let formatter = DateFormatter()
     @State var tasks = [OCKTask]()
     @State var userLoggedOut = false
     @State var isLoading = true
+    var displayDate: String
+    
+    init() {
+        formatter.dateFormat = "d MMM YYYY"
+        displayDate = formatter.string(from: Date())
+    }
     
     var body: some View {
         VStack {
@@ -56,11 +63,19 @@ struct CareKitListView: View {
                     LogoutUserView()
                 } else {
                     if tasks.isEmpty {
-                        NoTaskView()
+                        NoTaskView(displayDate: displayDate)
                     } else {
+                        HStack() {
+                            Text(displayDate)
+                                .fontWeight(.bold)
+                                .padding(.bottom, 5)
+                                .padding(.leading, 5)
+                            
+                            Spacer()
+                        }
                         List {
                             ForEach(tasks, id: \.id) { task in
-                                SimpleTaskView(taskID: task.id, eventQuery: .init(for: task.effectiveDate), storeManager: carekitstore.synchronizedStoreManager)
+                                SimpleTaskView(taskID: task.id, eventQuery: .init(for: Date()), storeManager: carekitstore.synchronizedStoreManager)
                             }
                         }
                     }

--- a/OTFMagicBoxWatch/Views/NoTaskView.swift
+++ b/OTFMagicBoxWatch/Views/NoTaskView.swift
@@ -9,17 +9,15 @@ import SwiftUI
 
 struct NoTaskView: View {
     
-    let formatter = DateFormatter()
-    var date: String
+    var displayDate: String
     
-    init() {
-        formatter.dateFormat = "d MMM YYYY"
-        date = formatter.string(from: Date())
+    init(displayDate: String) {
+        self.displayDate = displayDate
     }
     
     var body: some View {
         VStack(alignment: .leading) {
-            Text(date)
+            Text(displayDate)
                 .fontWeight(.bold)
                 .padding(.bottom, 5)
             VStack(alignment: .leading) {
@@ -38,5 +36,7 @@ struct NoTaskView: View {
 }
 
 #Preview {
-    NoTaskView()
+    let formatter = DateFormatter()
+    let displayDate = formatter.string(from: Date())
+    NoTaskView(displayDate: displayDate)
 }


### PR DESCRIPTION
Fixes watch `carekitlistview` to show current day scheduled events. This is how it looks now:

<img width="721" alt="Screenshot 2025-02-20 at 21 19 01" src="https://github.com/user-attachments/assets/f8f1a4df-004a-4b24-bf12-170598bc844a" />
